### PR TITLE
modifications to predict deliverable

### DIFF
--- a/VI_LUAD/predict.py
+++ b/VI_LUAD/predict.py
@@ -168,15 +168,12 @@ def compute_log_loss(results, prob_key="prob_vitumor"):
 # SECTION 5: MAIN (do not modify)
 # ============================================================================
 
-LEADERBOARD_OUTPUT_ROOT = "/projectnb/medaihack/VI_LUAD_Project/private/team_leaderboard_outputs"
-
-
 def main(args):
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     print(f"Device: {device}")
 
-    # Resolve output directory from team name
-    preds_dir = os.path.join(LEADERBOARD_OUTPUT_ROOT, args.team)
+    # Resolve output directory
+    preds_dir = os.path.join(args.out_dir, args.team)
 
     # Load leaderboard metadata
     print(f"\n[Loading leaderboard metadata]")
@@ -189,10 +186,10 @@ def main(args):
     model = load_checkpoint(args.checkpoint, device,
                             args.hidden_dim, args.dropout)
 
-    # Run inference
+    # Run inference (features live alongside the metadata file)
+    features_dir = str(Path(args.test_metadata).parent)
     print(f"\n[Running inference on leaderboard slides]")
-    slide_results = run_inference(model, test_metadata, args.features_dir,
-                                 device)
+    slide_results = run_inference(model, test_metadata, features_dir, device)
 
     # Patient aggregation
     print(f"\n[Aggregating per-patient predictions]")
@@ -246,13 +243,13 @@ def parse_args():
     )
     parser.add_argument(
         "--test_metadata",
-        default="/projectnb/medaihack/VI_LUAD_Project/private/processed_test/leaderboard_metadata.json",
-        help="DO NOT CHANGE. Path to leaderboard_metadata.json.",
+        required=True,
+        help="Path to leaderboard_metadata.json (provided by the organizers).",
     )
     parser.add_argument(
-        "--features_dir",
-        default="/projectnb/medaihack/VI_LUAD_Project/private/processed_test",
-        help="DO NOT CHANGE. Directory containing pre-extracted test features.",
+        "--out_dir",
+        default="predictions",
+        help="Directory to write prediction outputs (default: predictions/)",
     )
     parser.add_argument("--hidden_dim", type=int, default=256,
                         help="Must match the hidden_dim used during training")

--- a/VI_LUAD/predict.sh
+++ b/VI_LUAD/predict.sh
@@ -1,4 +1,17 @@
 #!/bin/bash -l
+# predict.sh — Run leaderboard inference for VI-LUAD
+# ====================================================
+# Usage:
+#     bash predict.sh <test_metadata.json> [out_dir]
+#
+# Arguments:
+#     test_metadata.json  — path to the leaderboard metadata JSON file
+#                           (provided by the organizers at evaluation time)
+#     out_dir             — (optional) directory to write predictions (default: predictions/)
+#
+# Example:
+#     bash predict.sh /path/to/leaderboard_metadata.json
+#     bash predict.sh /path/to/leaderboard_metadata.json /path/to/output
 
 ###############################################################################
 #                        LEADERBOARD PREDICTION JOB
@@ -41,9 +54,18 @@
 
 # =============================================================================
 
+if [ $# -lt 1 ]; then
+    echo "Usage: bash predict.sh <test_metadata.json> [out_dir]"
+    exit 1
+fi
+
 # ---- Fill in your settings ----
 TEAM=YOUR_TEAM                    # same as YOUR_TEAM in README
 CHECKPOINT=PATH/TO/YOUR_CKPT.pth
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_METADATA="$1"
+OUT_DIR="${2:-$SCRIPT_DIR/predictions}"
 
 # --- cd to the team's project directory --------------------------------------
 
@@ -62,7 +84,9 @@ echo "[INFO] Virtual environment '/projectnb/medaihack/$TEAM/vi_luad' activated.
 
 echo "[INFO] Running predict.py ..."
 python starter_code/predict.py \
-    --team        $TEAM \
-    --checkpoint  $CHECKPOINT
+    --team          $TEAM \
+    --checkpoint    $CHECKPOINT \
+    --test_metadata "$TEST_METADATA" \
+    --out_dir       "$OUT_DIR"
 
 echo "[INFO] predict.py finished with exit code $?"


### PR DESCRIPTION
### predict.sh

- Added usage header (matching BKBC's style) — accepts `<test_metadata.json> [out_dir]`
- Added argument validation (`[ $# -lt 1 ]`)
- `$1` → `TEST_METADATA`, `$2` → `OUT_DIR` (defaults to `$SCRIPT_DIR/predictions`)
- Passes `--test_metadata "$TEST_METADATA"` and `--out_dir "$OUT_DIR"` to `predict.py`


### predict.py

- Removed hardcoded `LEADERBOARD_OUTPUT_ROOT` constant and the private `/projectnb/medaihack/VI_LUAD_Project/private/... paths`
- `--test_metadata` is now `required=True` with no default (organizers pass it at eval time)
- `--features_dir` arg removed — features dir is now derived as the parent directory of the metadata JSON (since they live together)
- Added `--out_dir` argument in its place; output is written to `out_dir/TEAM/`
